### PR TITLE
Bump version to v0.1.8a0 due to massive pypi changes!

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6a0" %}
+{% set version = "0.1.8a0" %}
 
 package:
   name: ogh
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/ogh/ogh-{{ version }}.tar.gz
-  sha256: 4fa735bc1a731ce176627c7180f4cf896a355c394bc3e74a48cd44f420bdf1d6
+  sha256: 56f2404b2249316ebb9ea0fa716125ece6518f476bde0342f03d3938343c3fbe
 
 build:
   number: 0
@@ -26,6 +26,8 @@ requirements:
     - beautifulsoup4
     - basemap
     - python-wget
+    - seaborn
+    - basemap-data-hires
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,9 @@ requirements:
     - python-wget
     - seaborn
     - basemap-data-hires
+    - setuptools>=38.6.0
+    - twine>=1.11.0
+    - wheel>=0.31.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   build:
     - python
     - pip
+    - wheel >=0.31.0
+    - twine >=1.11.0
   run:
     - python
     - pandas
@@ -28,9 +30,6 @@ requirements:
     - python-wget
     - seaborn
     # - basemap-data-hires Note: This might be a problem?
-    - setuptools
-    - twine
-    - wheel
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,9 @@ requirements:
     - python-wget
     - seaborn
     - basemap-data-hires
-    - setuptools>=38.6.0
-    - twine>=1.11.0
-    - wheel>=0.31.0
+    - setuptools
+    - twine
+    - wheel
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - basemap
     - python-wget
     - seaborn
-    - basemap-data-hires
+    # - basemap-data-hires Note: This might be a problem?
     - setuptools
     - twine
     - wheel


### PR DESCRIPTION
This PR updates ogh to version 0.1.8a0 due to the massive pypi changes instead of 0.1.7a0 and also there were many package changes!