### PR TITLE
Bump version to v0.1.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6a0" %}
+{% set version = "0.1.11" %}
 
 package:
   name: ogh
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/ogh/ogh-{{ version }}.tar.gz
-  sha256: 4fa735bc1a731ce176627c7180f4cf896a355c394bc3e74a48cd44f420bdf1d6
+  sha256: bd71a25fc32a8d28f44b72e422b7db532de4281961ddbdffd631f9423ef3854f
 
 build:
   number: 0
@@ -26,6 +26,7 @@ requirements:
     - beautifulsoup4
     - basemap
     - python-wget
+    - landlab
 
 test:
   imports:


### PR DESCRIPTION
## Overview

This PR update the conda package version to `0.1.11` and adds landlab to dependency.